### PR TITLE
Replace Outdated `Get-Volume` with `Get-WmiObject` Method

### DIFF
--- a/Get-Windows-Readiness.ps1
+++ b/Get-Windows-Readiness.ps1
@@ -42,8 +42,8 @@ function InformIT {
 
 $Models = Get-Content -Path "$PSSCRIPTROOT\processors.csv" | convertfrom-csv -Header Manafacturer, series, model
 $Proc = (Get-CimInstance -ClassName Win32_Processor).name -split ' ' | ForEach-Object { $models | Where-Object -Property model -eq $_ }
-$Ram = (Get-WmiObject Win32_PhysicalMemory | Measure-Object -Property capacity -Sum | ForEach-Object {[Math]::Round(($_.sum / 1GB),2)}) -gt 4
-$Disk = ((Get-Volume | Where-Object DriveLetter -Match C).size) -gt 68719476736
+$Ram = (Get-WmiObject Win32_PhysicalMemory | Measure-Object -Property capacity -Sum | ForEach-Object { [Math]::Round(($_.sum / 1GB), 2) }) -gt 4
+$Disk = ((Get-WmiObject Win32_LogicalDisk | Select-Object DeviceID, Size, FreeSpace, VolumeName | Where-Object DeviceID -Match 'C:').size) -gt 68719476736
 #$BiosMode = (Confirm-SecureBootUEFI -ErrorVariable ProcessError)
 
 $Results = [PSCustomObject]@{


### PR DESCRIPTION
I replaced the `Get-Volume` command to detect C drive size with Get-WmiObject method for consistency and to allow this to function properly on desktop environments (not windows server) and recent powershell versions (other than v4 with the `Get-Volume` commandlet).

See <https://stackoverflow.com/questions/26168371/powershell-3-0-alternative-to-get-volume>.